### PR TITLE
Remove unnecessary memoization

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'dotenv-rails', groups: [:development, :test] 
+gem 'dotenv-rails', groups: [:development, :test]
 
 ruby '2.3.1'
 
@@ -34,7 +34,6 @@ gem 'twitter-bootstrap-rails'
 
 gem 'friendly_id', '~> 5.0.0'
 gem "recaptcha", require: "recaptcha/rails"
-#gem 'will_paginate'
 gem 'kaminari'
 gem 'obscenity'
 gem 'administrate', github: 'thoughtbot/administrate', branch: :master

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,7 +1,6 @@
 class PostsController < ApplicationController
 
   def index
-    params[:page] ||= 1
     @posts = Post.page(params[:page]).per(30).order(id: :desc)
   end
 


### PR DESCRIPTION
Looking at the implementation in Kaminari for the `page` method, this will handle `params[:page]` being `nil`, as calling `.to_i` on it will return `0`:
https://github.com/kaminari/kaminari/blob/master/kaminari-activerecord/lib/kaminari/activerecord/active_record_model_extension.rb#L16

Since `0` is the same as `1` per the docs, we can safely remove `params[:page] ||= 1`:
https://github.com/kaminari/kaminari#the-page-scope
> Note: pagination starts at page 1, not at page 0 (page(0) will return the same results as page(1)).

Also removed the commented `will_paginate` line in the Gemfile