### PR TITLE
Updating from FactoryGirl to FactoryBot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'dotenv-rails', groups: [:development, :test] 
+gem 'dotenv-rails', groups: [:development, :test]
 
 ruby '2.3.1'
 
@@ -57,7 +57,7 @@ end
 
 group :test do
   gem 'rspec-rails'
-  gem 'factory_girl_rails'
+  gem 'factory_bot_rails'
   gem 'database_cleaner'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,10 +98,10 @@ GEM
     erubis (2.7.0)
     eventmachine (1.2.5)
     execjs (2.7.0)
-    factory_girl (4.9.0)
+    factory_bot (4.11.1)
       activesupport (>= 3.0.0)
-    factory_girl_rails (4.9.0)
-      factory_girl (~> 4.9.0)
+    factory_bot_rails (4.11.1)
+      factory_bot (~> 4.11.1)
       railties (>= 3.0.0)
     ffi (1.9.18)
     formatador (0.2.5)
@@ -310,7 +310,7 @@ DEPENDENCIES
   coffee-rails (~> 4.0.0)
   database_cleaner
   dotenv-rails
-  factory_girl_rails
+  factory_bot_rails
   friendly_id (~> 5.0.0)
   guard-livereload
   heroku-deflater
@@ -339,4 +339,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.15.4
+   1.16.5

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,11 +1,11 @@
 FactoryBot.define do
   factory :category do
     factory :ruby_category do
-      name "Ruby"
+      name { "Ruby" }
     end
 
     factory :medical_category do
-      name "Medicine"
+      name { "Medicine" }
     end
   end
 end

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :category do
     factory :ruby_category do
       name "Ruby"

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :post do
     factory :ruby_post do
       association :category, factory: :ruby_category

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -2,14 +2,14 @@ FactoryBot.define do
   factory :post do
     factory :ruby_post do
       association :category, factory: :ruby_category
-      months_experience 6
-      inability "Testing"
+      months_experience { 6 }
+      inability { "Testing" }
     end
 
     factory :medical_post do
       association :category, factory: :medical_category
-      months_experience 3
-      inability "Pulse reading"
+      months_experience { 3 }
+      inability { "Pulse reading" }
     end
   end
 end

--- a/spec/features/visitor_creates_a_goofy_post_spec.rb
+++ b/spec/features/visitor_creates_a_goofy_post_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 feature "Creating a goofy post" do
   scenario "Visitor creates a new goofy post from the homepage 'new' link" do
-    ruby_category = FactoryGirl.create(:ruby_category)
-    ruby_post = FactoryGirl.create(:ruby_post, category: ruby_category)
+    ruby_category = FactoryBot.create(:ruby_category)
+    ruby_post = FactoryBot.create(:ruby_post, category: ruby_category)
 
     visit root_path
     expect(page).not_to have_content("this is a feature spec")
@@ -18,4 +18,3 @@ feature "Creating a goofy post" do
     expect(page).to have_css('li.goofy')
   end
 end
-

--- a/spec/features/visitor_views_a_category_spec.rb
+++ b/spec/features/visitor_views_a_category_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 feature "Viewing categories" do
-  let!(:ruby_post) { FactoryGirl.create(:ruby_post) }
-  let!(:med_post) { FactoryGirl.create(:medical_post) }
+  let!(:ruby_post) { FactoryBot.create(:ruby_post) }
+  let!(:med_post) { FactoryBot.create(:medical_post) }
 
   scenario "Visitor goes to categories list page" do
     visit categories_path

--- a/spec/features/visitor_views_index_spec.rb
+++ b/spec/features/visitor_views_index_spec.rb
@@ -7,18 +7,17 @@ feature "Viewing the listing of all posts" do
   end
 
   scenario "Visitor sees individual posts on index" do
-    ruby_category = FactoryGirl.create(:ruby_category)
-    ruby_post = FactoryGirl.create(:ruby_post)
+    ruby_category = FactoryBot.create(:ruby_category)
+    ruby_post = FactoryBot.create(:ruby_post)
     visit root_path
     expect(page).to have_content(ruby_post.inability)
   end
 
   scenario "Visitor clicks on a post" do
-    ruby_category = FactoryGirl.create(:ruby_category)
-    ruby_post = FactoryGirl.create(:ruby_post)
+    ruby_category = FactoryBot.create(:ruby_category)
+    ruby_post = FactoryBot.create(:ruby_post)
     visit root_path
     click_on(ruby_post.inability)
     expect(page).to have_content("I'm in the #{ ruby_category.name } field")
   end
 end
-

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -3,7 +3,7 @@ require 'pry'
 
 describe Category do
 
-  let(:category) { FactoryGirl.build(:ruby_category) }
+  let(:category) { FactoryBot.build(:ruby_category) }
 
   describe "has a #name" do
     it { should respond_to(:name) }
@@ -53,7 +53,7 @@ describe Category do
   describe "associations" do
 
     it "has many posts" do
-      post = FactoryGirl.create(:ruby_post, category: category)
+      post = FactoryBot.create(:ruby_post, category: category)
       expect(category.posts).not_to be_empty
     end
   end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Post do
 
-  let(:post) { FactoryGirl.build(:ruby_post) }
+  let(:post) { FactoryBot.build(:ruby_post) }
 
   describe "Factory" do
     it "is valid" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,7 +42,7 @@ RSpec.configure do |config|
   config.formatter = :documentation
 
   # Factory_Girl
-  config.include FactoryGirl::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
 
   # If you're not using ActiveRecord, or you'd prefer not to run 
   # each of your examples within a transaction, remove the following 


### PR DESCRIPTION
As the gem has been updated and changed its name from `FactoryGirl` to `FactoryBot`, I decided to make the the change [as suggested in the documentation of thoughtbot](https://github.com/thoughtbot/factory_bot/blob/4-9-0-stable/UPGRADE_FROM_FACTORY_GIRL.md).

After updating, I ran `rspec` and noticed that there was an error:

`DEPRECATION WARNING: Static attributes will be removed in FactoryBot 5.0. Please use dynamic
attributes instead by wrapping the attribute value in a block`.

To fix this warning and automatically update from static attributes to dynamic attributes, I installed locally `rubocop-rspec` and ran:

```
rubocop \
  --require rubocop-rspec \
  --only FactoryBot/AttributeDefinedStatically \
  --auto-correct
```

This warning was fixed in the second commit.