### PR TITLE
Fix jquery is not defined error in console

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,7 @@
 <head>
   <title>ImpostorRoster</title>
   <%= stylesheet_link_tag    "application", media: "all", "data-turbolinks-track" => true %>
-  <%= javascript_include_tag "application", "data-turbolinks-track" => true, async: true %>
+  <%= javascript_include_tag "application", "data-turbolinks-track" => true, async: Rails.env.production? %>
   <%= csrf_meta_tags %>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <script>


### PR DESCRIPTION
There were 15 errors in console just like that:
- `Uncaught ReferenceError: jQuery is not defined`
- `Uncaught ReferenceError: $ is not defined`

The solution was deactivate async load in js and activate it only in production.